### PR TITLE
Updated read_aws function to include current set of headers 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,4 +22,4 @@ Imports:
     Rcpp,
     readr
 VignetteBuilder: knitr
-RoxygenNote: 6.0.1
+RoxygenNote: 7.1.0

--- a/R/readers.R
+++ b/R/readers.R
@@ -227,6 +227,27 @@ read_squid <- function(file, has_header = FALSE){
 #'  is a hyphen (-).}
 #'  \item{response_result_type: }{How CloudFront classified the response just
 #'  before returning the response to the viewer.}
+#'  \item{protocol_version: }{The HTTP version that the viewer specified in the
+#'  request.}
+#'  \item{fle_status: }{When field-level encryption is configured for a
+#'  distribution, this field contains a code that indicates whether the request
+#'  body was successfully processed.}
+#'  \item{fle_encrypted_fields: }{The number of fields that CloudFront encrypted
+#'  and forwarded to the origin.}
+#'  \item{port: }{The port number of the request from the viewer.}
+#'  \item{time_to_first_byte: }{The number of seconds between receiving the
+#'  request and writing the first byte of the response, as measured on the
+#'  server.}
+#'  \item{detailed_result_type: }{When \code{result_type} is not Error, this
+#'  field contains the same value as \code{result_type}.}
+#'  \item{content_type: }{The value of the HTTP Content-Type header of the
+#'  response.}
+#'  \item{content_length: }{The value of the HTTP Content-Length header of
+#'  the response.}
+#'  \item{content_range_start: }{When the response contains the HTTP
+#'  Content-Range header, this field contains the range start value.}
+#'  \item{content_range_end: }{When the response contains the HTTP
+#'  Content-Range header, this field contains the range end value.}
 #'}
 #'
 #'@seealso \code{\link{read_s3}}, for Amazon S3 files,

--- a/R/readers.R
+++ b/R/readers.R
@@ -263,7 +263,7 @@ read_aws <- function(file){
   formatters <- aws_header_select(header_fields)
   data <- read_delim(file = file, delim = "\t", escape_backslash = FALSE,
                      col_names = formatters[[1]], col_types = formatters[[2]],
-                     skip = 2)
+                     skip = 2, na = c("", "NA", "-"))
   
   if(all(c("date","time") %in% names(data))){
     data$date <- as.POSIXct(paste(data$date, data$time), tz = "UTC")

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -36,7 +36,7 @@ aws_header_select <- function(header_fields){
                      col_number(), col_character(), col_character(), 
                      col_character(), col_character(), col_character(),
                      col_character(), col_integer(), col_integer(),
-                     col_number(), col_character(), col_integer(),
+                     col_number(), col_character(), col_character(),
                      col_integer(), col_integer(), col_integer())
   
   if(length(header_fields) == length(field_names) &&

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -10,7 +10,11 @@ aws_header_select <- function(header_fields){
                    "cs(Cookie)", "x-edge-result-type", "x-edge-request-id", 
                    "x-host-header", "cs-protocol", "cs-bytes", "time-taken",
                    "x-forwarded-for", "ssl-protocol", "ssl-cipher", 
-                   "x-edge-response-result-type")
+                   "x-edge-response-result-type", "cs-protocol-version",
+                   "fle-status", "fle-encrypted-fields", "c-port", 
+                   "time-to-first-byte", "x-edge-detailed-result-type",
+                   "sc-content-type", "sc-content-len", "sc-range-start",
+                   "sc-range-end")
   
 
   new_names <- c("date", "time", "edge_location", "bytes_sent", "ip_address",
@@ -18,7 +22,10 @@ aws_header_select <- function(header_fields){
                  "user_agent", "query", "cookie", "result_type", "request_id",
                  "host_header", "protocol", "bytes_received", "time_elapsed",
                  "forwarded_for", "ssl_protocol", "ssl_cipher", 
-                 "response_result_type")
+                 "response_result_type", "protocol_version", "fle_status",
+                 "fle_encrypted_fields", "port", "time_to_first_byte",
+                 "detailed_result_type", "content_type", "content_length",
+                 "content_range_start", "content_range_end")
   
   collectors <- list(col_character(), col_character(), col_character(),
                      col_integer(), col_character(), col_character(), 
@@ -27,8 +34,10 @@ aws_header_select <- function(header_fields){
                      col_character(), col_character(), col_character(),
                      col_character(), col_character(), col_character(),
                      col_number(), col_character(), col_character(), 
-                     col_character(), col_character()
-  )
+                     col_character(), col_character(), col_character(),
+                     col_character(), col_integer(), col_integer(),
+                     col_number(), col_character(), col_integer(),
+                     col_integer(), col_integer(), col_integer())
   
   if(length(header_fields) == length(field_names) &&
      all(header_fields == field_names)) {

--- a/README.md
+++ b/README.md
@@ -22,4 +22,4 @@ For the released version:
 For the development version:
 
     library(devtools)
-    install_github("ironholds/webreadr", INSTALL_opts = c("--no-multiarch"))
+    install_github("ironholds/webreadr")

--- a/README.md
+++ b/README.md
@@ -22,4 +22,4 @@ For the released version:
 For the development version:
 
     library(devtools)
-    install_github("ironholds/webreadr")
+    install_github("ironholds/webreadr", INSTALL_opts = c("--no-multiarch"))

--- a/man/read_aws.Rd
+++ b/man/read_aws.Rd
@@ -78,6 +78,27 @@ Amazon CloudFront uses tab-separated files with
  is a hyphen (-).}
  \item{response_result_type: }{How CloudFront classified the response just
  before returning the response to the viewer.}
+ \item{protocol_version: }{The HTTP version that the viewer specified in the
+ request.}
+ \item{fle_status: }{When field-level encryption is configured for a
+ distribution, this field contains a code that indicates whether the request
+ body was successfully processed.}
+ \item{fle_encrypted_fields: }{The number of fields that CloudFront encrypted
+ and forwarded to the origin.}
+ \item{port: }{The port number of the request from the viewer.}
+ \item{time_to_first_byte: }{The number of seconds between receiving the
+ request and writing the first byte of the response, as measured on the
+ server.}
+ \item{detailed_result_type: }{When \code{result_type} is not Error, this
+ field contains the same value as \code{result_type}.}
+ \item{content_type: }{The value of the HTTP Content-Type header of the
+ response.}
+ \item{content_length: }{The value of the HTTP Content-Length header of
+ the response.}
+ \item{content_range_start: }{When the response contains the HTTP
+ Content-Range header, this field contains the range start value.}
+ \item{content_range_end: }{When the response contains the HTTP
+ Content-Range header, this field contains the range end value.}
 }
 }
 \examples{


### PR DESCRIPTION
This updates the (currently broken) aws_header_select function to include the set of headers as they are included in AWS CloudFront log files as of 10/2020.

(The headers remain hardcoded and might break again upon future changes to the logfile format.)